### PR TITLE
Fix bug when parent context is removed and component is no longer in DOM

### DIFF
--- a/addon/components/highlight-terms/component.js
+++ b/addon/components/highlight-terms/component.js
@@ -37,14 +37,14 @@ const HighlightTerm = Ember.Component.extend({
         }, []);
       }
 
-      if (this._state == "inDOM") {
+      if (this.$()) {
         this.$().highlight(term, options);
       }
     }
   },
 
   unhighlight() {
-    if (this._state == "inDOM") {
+    if (this.$()) {
       this.$().unhighlight();
     }
   }

--- a/addon/components/highlight-terms/component.js
+++ b/addon/components/highlight-terms/component.js
@@ -37,12 +37,16 @@ const HighlightTerm = Ember.Component.extend({
         }, []);
       }
 
-      this.$().highlight(term, options);
+      if (this._state == "inDOM") {
+        this.$().highlight(term, options);
+      }
     }
   },
 
   unhighlight() {
-    this.$().unhighlight();
+    if (this._state == "inDOM") {
+      this.$().unhighlight();
+    }
   }
 });
 


### PR DESCRIPTION
I had an issue with highlighting items rendered with `{{#each}}` and in some situations (maybe there are some race conditions involved here) when items were filtered out, `this.$()` was `undefined` and causing errors.
