### PR TITLE
Add jquery-highlight dependency to vendor imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     this._super.included.apply(this, arguments);
     this.import('vendor/simple.css');
     this.import('vendor/shims/jquery-highlight.js');
+    this.import('vendor/jquery.highlight.js');
   },
 
   treeForVendor(vendorTree) {


### PR DESCRIPTION
It looks like this has defined the highlight code to be added to the vendor tree, but it isn't actually included as an import when `vendor.js` is created. This should add the required code to the `vendor.js` output. This appears to fix the issues I described in #1. Sorry for hijacking that issue.